### PR TITLE
Fix Build Error

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,24 @@
 {
   "pins" : [
     {
+      "identity" : "collectionconcurrencykit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/JohnSundell/CollectionConcurrencyKit.git",
+      "state" : {
+        "revision" : "b4f23e24b5a1bff301efc5e70871083ca029ff95",
+        "version" : "0.2.0"
+      }
+    },
+    {
+      "identity" : "cryptoswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
+      "state" : {
+        "revision" : "c9c3df6ab812de32bae61fc0cd1bf6d45170ebf0",
+        "version" : "1.8.2"
+      }
+    },
+    {
       "identity" : "files",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/johnsundell/files.git",
@@ -10,9 +28,18 @@
       }
     },
     {
+      "identity" : "sourcekitten",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/SourceKitten.git",
+      "state" : {
+        "revision" : "b6dc09ee51dfb0c66e042d2328c017483a1a5d56",
+        "version" : "0.34.1"
+      }
+    },
+    {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
         "revision" : "8f4d2753f0e4778c76d5f05ad16c74f707390531",
         "version" : "1.2.3"
@@ -28,6 +55,15 @@
       }
     },
     {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "6ad4ea24b01559dde0773e3d091f1b9e36175036",
+        "version" : "509.0.2"
+      }
+    },
+    {
       "identity" : "swift-version-file-plugin",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mobelux/swift-version-file-plugin.git",
@@ -37,12 +73,39 @@
       }
     },
     {
+      "identity" : "swiftlint",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/realm/SwiftLint.git",
+      "state" : {
+        "revision" : "f17a4f9dfb6a6afb0408426354e4180daaf49cee",
+        "version" : "0.54.0"
+      }
+    },
+    {
+      "identity" : "swiftytexttable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/scottrhoyt/SwiftyTextTable.git",
+      "state" : {
+        "revision" : "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
+        "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "swxmlhash",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/drmohundro/SWXMLHash.git",
+      "state" : {
+        "revision" : "a853604c9e9a83ad9954c7e3d2a565273982471f",
+        "version" : "7.0.2"
+      }
+    },
+    {
       "identity" : "xctest-dynamic-overlay",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "b58e6627149808b40634c4552fcf2f44d0b3ca87",
-        "version" : "1.1.0"
+        "revision" : "6f30bdba373bbd7fbfe241dddd732651f2fbd1e2",
+        "version" : "1.1.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -61,8 +61,8 @@ let package = Package(
 )
 
 #if os(macOS)
-package.dependencies.append(.package(url: "https://github.com/realm/SwiftLint.git", from: "0.55.0"))
+package.dependencies.append(.package(url: "https://github.com/realm/SwiftLint.git", exact: "0.54.0"))
 for target in package.targets.filter({ if case .plugin = $0.type { return false } else { return true } }) {
-    target.plugins = [.plugin(name: "SwiftLintBuildToolPlugin", package: "SwiftLint")]
+    target.plugins = [.plugin(name: "SwiftLintPlugin", package: "SwiftLint")]
 }
 #endif

--- a/Sources/package-manifest-generator/Tool.swift
+++ b/Sources/package-manifest-generator/Tool.swift
@@ -21,10 +21,12 @@ struct Tool: AsyncParsableCommand {
             help: "The path to the generator configuration file.",
             completion: .file())
     var configurationPath: String?
+    // swiftlint:disable:previous let_var_whitespace
 
     @Option(help: "The package path to operate on (default current directory).",
             completion: .directory)
     var packagePath: String?
+    // swiftlint:disable:previous let_var_whitespace
 
     /// Runs the tool.
     mutating func run() async throws {


### PR DESCRIPTION
SwiftLint 0.55.0 renamed its build tool plugin, breaking this package when building on macOS; this specifies an exact SwiftLint version (`0.54.0` as `0.55.0` + specifies a version of `SwiftSyntax` that is incompatible with the one used by TCA `1.6.0`)