### PR TITLE
Fix SwiftLint Warning in Generated Manifest

### DIFF
--- a/Sources/PackageManifestGeneratorCore/SourceGenerator.swift
+++ b/Sources/PackageManifestGeneratorCore/SourceGenerator.swift
@@ -43,10 +43,8 @@ struct SourceGenerator {
 
         var \(Constants.generatedTargetsName): [Target] = \(targetStrings.asSourceArray(indentationStyle: indentationStyle))
 
-        for target in \(Constants.generatedTargetsName) {
-            if !target.exclude.contains(\(targetConfigurationName.quoted())) {
-                target.exclude.append(\(targetConfigurationName.quoted()))
-            }
+        for target in \(Constants.generatedTargetsName) where !target.exclude.contains(\(targetConfigurationName.quoted())) {
+            target.exclude.append(\(targetConfigurationName.quoted()))
         }
         """
     }


### PR DESCRIPTION
Fixes a SwiftLint "Prefer For-Where Violation" in output.